### PR TITLE
[#23] Pullapprove config change

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -28,7 +28,7 @@ group_defaults:
 
 groups:
   regular:
-    required: 2
+    required: 1
 
     teams:
       - coders


### PR DESCRIPTION
Only one person is required to approve a pull request.